### PR TITLE
Issue4

### DIFF
--- a/checkmate/src/main/java/com/gmbbd/checkMate/controller/AnalyzeController.java
+++ b/checkmate/src/main/java/com/gmbbd/checkMate/controller/AnalyzeController.java
@@ -1,0 +1,32 @@
+package com.gmbbd.checkMate.controller;
+
+import com.gmbbd.checkMate.model.EvaluationResult;
+import com.gmbbd.checkMate.model.SummaryResponse;
+import com.gmbbd.checkMate.service.AnalysisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AnalyzeController {
+
+    private final AnalysisService analysisService;
+
+    @PostMapping(
+            value = "/analyze",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public SummaryResponse analyze(
+            @RequestPart("requirements") MultipartFile req,
+            @RequestPart("submission") MultipartFile sub
+    ) {
+        List<EvaluationResult> results = analysisService.evaluate(req, sub);
+
+        return SummaryResponse.from(results);
+    }
+}

--- a/checkmate/src/main/java/com/gmbbd/checkMate/controller/ReportController.java
+++ b/checkmate/src/main/java/com/gmbbd/checkMate/controller/ReportController.java
@@ -1,0 +1,28 @@
+package com.gmbbd.checkMate.controller;
+
+import com.gmbbd.checkMate.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ReportController {
+
+    private final ReportService reportService; // 보고서 생성
+
+    @PostMapping(
+            value = "/report",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.TEXT_PLAIN_VALUE
+    )
+    public String generateReport(
+            @RequestPart("requirements") MultipartFile requirements, // 요구사항 문서 파일
+            @RequestPart("submission") MultipartFile submission       // 제출물 문서 파일
+    ) {
+        // 두 파일을 넘겨서 서비스 계층에서 TXT 리포트 생성 후 그대로 문자열 반환
+        return reportService.generateReport(requirements, submission);
+    }
+}

--- a/checkmate/src/main/java/com/gmbbd/checkMate/model/SummaryResponse.java
+++ b/checkmate/src/main/java/com/gmbbd/checkMate/model/SummaryResponse.java
@@ -1,0 +1,40 @@
+package com.gmbbd.checkMate.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SummaryResponse {
+
+    private int fulfilled;
+    private int partial;
+    private int notFulfilled;
+    private double score;
+
+    private List<EvaluationResult> details;
+
+    public static SummaryResponse from(List<EvaluationResult> results) {
+
+        int f = 0, p = 0, u = 0;
+        double scoreSum = 0;
+
+        for (EvaluationResult r : results) {
+            switch (r.getStatus()) {
+                case "FULFILLED" -> f++;
+                case "PARTIAL" -> p++;
+                default -> u++;
+            }
+            scoreSum += r.getScore();
+        }
+
+        int total = results.size();
+        double finalScore = total == 0 ? 0 : (scoreSum / total) * 100;
+
+        return new SummaryResponse(f, p, u, finalScore, results);
+    }
+}

--- a/checkmate/src/main/java/com/gmbbd/checkMate/service/ReportService.java
+++ b/checkmate/src/main/java/com/gmbbd/checkMate/service/ReportService.java
@@ -1,0 +1,48 @@
+package com.gmbbd.checkMate.service;
+
+import com.gmbbd.checkMate.model.EvaluationResult;
+import com.gmbbd.checkMate.model.SummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final AnalysisService analysisService;
+
+    public String generateReport(MultipartFile requirements, MultipartFile submission) {
+
+        SummaryResponse summary = SummaryResponse.from(
+                analysisService.evaluate(requirements, submission)
+        );
+
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("[Checkmate 분석 보고서]\n");
+        sb.append("============================================\n\n");
+
+        sb.append("총 요구사항 수 : ").append(summary.getDetails().size()).append("\n");
+        sb.append("- 충족(FULFILLED)       : ").append(summary.getFulfilled()).append("\n");
+        sb.append("- 부분 충족(PARTIAL)    : ").append(summary.getPartial()).append("\n");
+        sb.append("- 미충족(NOT_FULFILLED) : ").append(summary.getNotFulfilled()).append("\n\n");
+
+        sb.append("============================================\n");
+        sb.append("         요구사항별 상세 분석 결과\n");
+        sb.append("============================================\n\n");
+
+        for (EvaluationResult r : summary.getDetails()) {
+
+            sb.append("■ 요구사항 #").append(r.getRequirementId()).append("\n");
+            sb.append("내용   : ").append(r.getRequirementText()).append("\n");
+            sb.append("판정   : ").append(r.getStatus()).append("\n");
+            sb.append("근거   : ").append(
+                    r.getEvidence() != null ? r.getEvidence() : "근거 없음"
+            ).append("\n");
+            sb.append("--------------------------------------------\n\n");
+        }
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary

Implement Analyze (`/api/analyze`) and Report (`/api/report`) endpoints.  
Aggregate evaluation results into `SummaryResponse` and generate TXT reports.

---

## Related Issue

Closes #12

---

## Changes

### Controller
- `AnalyzeController`
- `ReportController`

### Service
- `ReportService`

### Model
- `SummaryResponse`

---

## Details

### 1. AnalyzeController
- Accepts `requirements` and `submission` as multipart files  
- Calls `AnalysisService.evaluate()`  
- Returns aggregated `SummaryResponse`

### 2. ReportController
- Accepts same two files  
- Calls `ReportService.generateReport()`  
- Returns human-readable TXT report

### 3. SummaryResponse
- Aggregates evaluation results  
- Counts FULFILLED / PARTIAL / NOT_FULFILLED  
- Computes average score  
- Stores full `EvaluationResult` list  
- Provides static `from()` factory method  

### 4. ReportService
- Calls evaluation pipeline  
- Builds TXT report containing:  
  - Global statistics  
  - Per-requirement status, evidence  
- Returns formatted text result

---

## Checklist
- [x] Code builds  
- [x] Endpoints tested  
- [ ] Docs updated  
- [x] No sensitive data committed  
